### PR TITLE
Corrección cabecera budget grid

### DIFF
--- a/templates/entities/show.html
+++ b/templates/entities/show.html
@@ -139,7 +139,7 @@
       var grid = createBudgetGrid("#myGrid", gridData[uiState.view], [
         {
           field: "label", 
-          name: ( uiState.field == 'fexpense' ? '{{ _("Política") }}' : '{{ _("Artículo") }}' ),
+          name: ( uiState.view == 'fexpense' ? '{{ _("Política") }}' : '{{ _("Artículo") }}' ),
           formatter: entityLinkFormatter,
           sortable: true,
           uiState: uiState


### PR DESCRIPTION
Creo que aquí hay un bug, uiState.field contiene 'expense' tanto para categoría Funcional como Económica, lo que hace que se muestre siempre 'Artículo' en la cabecera de la tabla y nunca 'Política'. Creo que se debe usar uiState.view que diferencia correctamente entre 'expense' y 'fexpense'.